### PR TITLE
Fixing non-compilation errors due to nonfree fonts

### DIFF
--- a/English/cl-reference.tex
+++ b/English/cl-reference.tex
@@ -4,8 +4,6 @@
 \usepackage[paperwidth=7.5in, paperheight=9.25in,
             inner=35mm, outer=25mm,
             tmargin=25mm, bmargin=30mm]{geometry}
-\usepackage[T1]{fontenc}
-\usepackage[utf8]{inputenc}
 \usepackage{alltt}
 \usepackage{moreverb}
 \usepackage{fancyvrb}


### PR DESCRIPTION
Two little lines there cause non-compilation on my machine, due to me being on a fully-free distro using fully-free fonts. Given that you plan to have this be as close to the public domain as possible, you may want to avoid gratuitous use of proprietary fonts.
