### PR TITLE
Putting utf8 encoding back in

### DIFF
--- a/English/cl-reference.tex
+++ b/English/cl-reference.tex
@@ -4,6 +4,7 @@
 \usepackage[paperwidth=7.5in, paperheight=9.25in,
             inner=35mm, outer=25mm,
             tmargin=25mm, bmargin=30mm]{geometry}
+\usepackage[utf8]{inputenc}
 \usepackage{alltt}
 \usepackage{moreverb}
 \usepackage{fancyvrb}


### PR DESCRIPTION
It seems I *had* been somewhat overzealous - it would appear that the encoding is a non-issue with respect to nonfree fonts. I've put it back as it was - sorry about that.